### PR TITLE
[SCRATCH] consume facetimehd-kmod-pr COPR (kmodtool PR validation)

### DIFF
--- a/files/scripts/build-kmod-facetimehd.sh
+++ b/files/scripts/build-kmod-facetimehd.sh
@@ -24,7 +24,7 @@ WORKDIR="$(mktemp -d)"
 (
   cd "${WORKDIR}"
   dnf5 download --source akmod-facetimehd
-  rpmbuild --rebuild --define "_topdir ${WORKDIR}/rpmbuild" akmod-facetimehd-*.src.rpm
+  rpmbuild --rebuild --define "_topdir ${WORKDIR}/rpmbuild" facetimehd-kmod-*.src.rpm
 )
 
 dnf5 install -y "${WORKDIR}"/rpmbuild/RPMS/*/akmod-facetimehd-*.rpm

--- a/files/scripts/build-kmod-facetimehd.sh
+++ b/files/scripts/build-kmod-facetimehd.sh
@@ -8,18 +8,20 @@ RELEASE="$(rpm -E '%fedora')"
 
 dnf5 -y copr enable mulderje/facetimehd-kmod
 
-# Ensure akmods is installed first so its scriptlet creates the akmods
-# system user; without it, akmods' runuser -u akmods fallback trips
-# akmodsbuild's "Not to be used as root" guard during the OCI build.
-dnf5 install -y akmods
-getent passwd akmods >/dev/null 2>&1 || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
-
 ### BUILD facetimehd (succeed or fail-fast with debug output)
-# Skip scriptlets: the akmod-*.rpm %post auto-invokes akmods and trips
-# akmodsbuild's root guard inside the OCI build. We invoke akmods
-# explicitly below to perform the real build.
-dnf5 install -y --setopt=tsflags=noscripts \
+# Install akmods first so its scriptlets create the `akmods` system user.
+# In minimal OCI builds, the implicit Requires: chain from akmod-facetimehd
+# sometimes leaves the user uncreated, which makes `akmods` fall through
+# to invoking akmodsbuild as root and trip its "-w /" guard:
+#   >>> ERROR: Not to be used as root; start as user or 'akmodsbuild' instead.
+dnf5 install -y \
+  akmods \
   akmod-facetimehd-*.fc${RELEASE}.${ARCH}
+
+# Belt-and-braces: if the scriptlet still didn't create the user, do it now.
+getent passwd akmods >/dev/null \
+  || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
+
 akmods --force --kernels "${KERNEL}" --kmod facetimehd
 modinfo "/usr/lib/modules/${KERNEL}/extra/facetimehd/facetimehd.ko.xz" >/dev/null ||
   (find /var/cache/akmods/facetimehd/ -name \*.log -print -exec cat {} \; && exit 1)

--- a/files/scripts/build-kmod-facetimehd.sh
+++ b/files/scripts/build-kmod-facetimehd.sh
@@ -6,19 +6,29 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME:-kernel}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-dnf5 -y copr enable mulderje/facetimehd-kmod-pr
+# [SCRATCH] Local rebuild of akmod-facetimehd against the patched kmodtool
+# from koji scratch task 144642202 (Fedora dist-git kmodtool PR #18). With
+# the patched kmodtool in the rpmbuild chroot, the generated %post line
+# ends in ` || :` so the akmods-ostree-post call is non-fatal and the OCI
+# install transaction no longer aborts on akmodsbuild's root guard. Remove
+# this block once the upstream kmodtool fix ships in stable Fedora and the
+# mulderje/facetimehd-kmod COPR rebuilds against it.
+dnf5 install -y --nogpgcheck \
+  https://kojipkgs.fedoraproject.org/work/tasks/2312/144642312/kmodtool-1.2-4.fc45.noarch.rpm
 
-### BUILD facetimehd (succeed or fail-fast with debug output)
-# Install akmods first so its scriptlets create the `akmods` system user.
-# In minimal OCI builds, the implicit Requires: chain from akmod-facetimehd
-# sometimes leaves the user uncreated, which makes `akmods` fall through
-# to invoking akmodsbuild as root and trip its "-w /" guard:
-#   >>> ERROR: Not to be used as root; start as user or 'akmodsbuild' instead.
-dnf5 install -y \
-  akmods \
-  akmod-facetimehd-*.fc${RELEASE}.${ARCH}
+dnf5 install -y rpm-build "kernel-devel-${KERNEL}"
 
-# Belt-and-braces: if the scriptlet still didn't create the user, do it now.
+dnf5 -y copr enable mulderje/facetimehd-kmod
+
+WORKDIR="$(mktemp -d)"
+(
+  cd "${WORKDIR}"
+  dnf5 download --source akmod-facetimehd
+  rpmbuild --rebuild --define "_topdir ${WORKDIR}/rpmbuild" akmod-facetimehd-*.src.rpm
+)
+
+dnf5 install -y "${WORKDIR}"/rpmbuild/RPMS/*/akmod-facetimehd-*.rpm
+
 getent passwd akmods >/dev/null \
   || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
 
@@ -26,4 +36,4 @@ akmods --force --kernels "${KERNEL}" --kmod facetimehd
 modinfo "/usr/lib/modules/${KERNEL}/extra/facetimehd/facetimehd.ko.xz" >/dev/null ||
   (find /var/cache/akmods/facetimehd/ -name \*.log -print -exec cat {} \; && exit 1)
 
-dnf5 -y copr disable mulderje/facetimehd-kmod-pr
+dnf5 -y copr disable mulderje/facetimehd-kmod

--- a/files/scripts/build-kmod-facetimehd.sh
+++ b/files/scripts/build-kmod-facetimehd.sh
@@ -16,7 +16,7 @@ RELEASE="$(rpm -E '%fedora')"
 dnf5 install -y --nogpgcheck \
   https://kojipkgs.fedoraproject.org/work/tasks/2312/144642312/kmodtool-1.2-4.fc45.noarch.rpm
 
-dnf5 install -y rpm-build "kernel-devel-${KERNEL}"
+dnf5 install -y rpm-build dnf5-plugins "kernel-devel-${KERNEL}"
 
 dnf5 -y copr enable mulderje/facetimehd-kmod
 
@@ -24,6 +24,7 @@ WORKDIR="$(mktemp -d)"
 (
   cd "${WORKDIR}"
   dnf5 download --source akmod-facetimehd
+  dnf5 builddep -y facetimehd-kmod-*.src.rpm
   rpmbuild --rebuild --define "_topdir ${WORKDIR}/rpmbuild" facetimehd-kmod-*.src.rpm
 )
 

--- a/files/scripts/build-kmod-facetimehd.sh
+++ b/files/scripts/build-kmod-facetimehd.sh
@@ -6,7 +6,7 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME:-kernel}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-dnf5 -y copr enable mulderje/facetimehd-kmod
+dnf5 -y copr enable mulderje/facetimehd-kmod-pr
 
 ### BUILD facetimehd (succeed or fail-fast with debug output)
 # Install akmods first so its scriptlets create the `akmods` system user.
@@ -26,4 +26,4 @@ akmods --force --kernels "${KERNEL}" --kmod facetimehd
 modinfo "/usr/lib/modules/${KERNEL}/extra/facetimehd/facetimehd.ko.xz" >/dev/null ||
   (find /var/cache/akmods/facetimehd/ -name \*.log -print -exec cat {} \; && exit 1)
 
-dnf5 -y copr disable mulderje/facetimehd-kmod
+dnf5 -y copr disable mulderje/facetimehd-kmod-pr

--- a/files/scripts/build-kmod-facetimehd.sh
+++ b/files/scripts/build-kmod-facetimehd.sh
@@ -8,6 +8,12 @@ RELEASE="$(rpm -E '%fedora')"
 
 dnf5 -y copr enable mulderje/facetimehd-kmod
 
+# Ensure akmods is installed first so its scriptlet creates the akmods
+# system user; without it, akmods' runuser -u akmods fallback trips
+# akmodsbuild's "Not to be used as root" guard during the OCI build.
+dnf5 install -y akmods
+getent passwd akmods >/dev/null 2>&1 || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
+
 ### BUILD facetimehd (succeed or fail-fast with debug output)
 dnf5 install -y \
   akmod-facetimehd-*.fc${RELEASE}.${ARCH}

--- a/files/scripts/build-kmod-facetimehd.sh
+++ b/files/scripts/build-kmod-facetimehd.sh
@@ -15,7 +15,10 @@ dnf5 install -y akmods
 getent passwd akmods >/dev/null 2>&1 || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
 
 ### BUILD facetimehd (succeed or fail-fast with debug output)
-dnf5 install -y \
+# Skip scriptlets: the akmod-*.rpm %post auto-invokes akmods and trips
+# akmodsbuild's root guard inside the OCI build. We invoke akmods
+# explicitly below to perform the real build.
+dnf5 install -y --setopt=tsflags=noscripts \
   akmod-facetimehd-*.fc${RELEASE}.${ARCH}
 akmods --force --kernels "${KERNEL}" --kmod facetimehd
 modinfo "/usr/lib/modules/${KERNEL}/extra/facetimehd/facetimehd.ko.xz" >/dev/null ||

--- a/files/scripts/build-kmod-wl.sh
+++ b/files/scripts/build-kmod-wl.sh
@@ -12,18 +12,20 @@ dnf5 install -y \
   https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
   https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
 
-# Ensure akmods is installed first so its scriptlet creates the akmods
-# system user; without it, akmods' runuser -u akmods fallback trips
-# akmodsbuild's "Not to be used as root" guard during the OCI build.
-dnf5 install -y akmods
-getent passwd akmods >/dev/null 2>&1 || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
-
 ### BUILD wl (succeed or fail-fast with debug output)
-# Skip scriptlets: the akmod-*.rpm %post auto-invokes akmods and trips
-# akmodsbuild's root guard inside the OCI build. We invoke akmods
-# explicitly below to perform the real build.
-dnf5 install -y --setopt=tsflags=noscripts \
+# Install akmods first so its scriptlets create the `akmods` system user.
+# In minimal OCI builds, the implicit Requires: chain from akmod-wl
+# sometimes leaves the user uncreated, which makes `akmods` fall through
+# to invoking akmodsbuild as root and trip its "-w /" guard:
+#   >>> ERROR: Not to be used as root; start as user or 'akmodsbuild' instead.
+dnf5 install -y \
+  akmods \
   akmod-wl-*.fc${RELEASE}.${ARCH}
+
+# Belt-and-braces: if the scriptlet still didn't create the user, do it now.
+getent passwd akmods >/dev/null \
+  || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
+
 akmods --force --kernels "${KERNEL}" --kmod wl
 modinfo /usr/lib/modules/${KERNEL}/extra/wl/wl.ko.xz >/dev/null ||
   (find /var/cache/akmods/wl/ -name \*.log -print -exec cat {} \; && exit 1)

--- a/files/scripts/build-kmod-wl.sh
+++ b/files/scripts/build-kmod-wl.sh
@@ -19,7 +19,10 @@ dnf5 install -y akmods
 getent passwd akmods >/dev/null 2>&1 || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
 
 ### BUILD wl (succeed or fail-fast with debug output)
-dnf5 install -y \
+# Skip scriptlets: the akmod-*.rpm %post auto-invokes akmods and trips
+# akmodsbuild's root guard inside the OCI build. We invoke akmods
+# explicitly below to perform the real build.
+dnf5 install -y --setopt=tsflags=noscripts \
   akmod-wl-*.fc${RELEASE}.${ARCH}
 akmods --force --kernels "${KERNEL}" --kmod wl
 modinfo /usr/lib/modules/${KERNEL}/extra/wl/wl.ko.xz >/dev/null ||

--- a/files/scripts/build-kmod-wl.sh
+++ b/files/scripts/build-kmod-wl.sh
@@ -12,6 +12,12 @@ dnf5 install -y \
   https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
   https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
 
+# Ensure akmods is installed first so its scriptlet creates the akmods
+# system user; without it, akmods' runuser -u akmods fallback trips
+# akmodsbuild's "Not to be used as root" guard during the OCI build.
+dnf5 install -y akmods
+getent passwd akmods >/dev/null 2>&1 || useradd -r -s /sbin/nologin -d /var/cache/akmods akmods
+
 ### BUILD wl (succeed or fail-fast with debug output)
 dnf5 install -y \
   akmod-wl-*.fc${RELEASE}.${ARCH}


### PR DESCRIPTION
## Summary

**DO NOT MERGE.** Scratch PR to validate end-to-end that the patched
`kmodtool` (koji scratch `kmodtool-1.2-4.fc45`, task 144642202, from
Fedora dist-git kmodtool PR
[#18](https://src.fedoraproject.org/rpms/kmodtool/pull-request/18))
produces an `akmod-facetimehd` whose `%post` ends in ` || :` and thus
installs cleanly in the OCI BlueBuild image build — unblocking the
`akmodsbuild` root-guard trip documented in #24.

Sibling to [`mulderje/facetimehd-kmod-rpm#5`](https://github.com/mulderje/facetimehd-kmod-rpm/pull/5),
which redirects its Packit `pull_request` job to the
`mulderje/facetimehd-kmod-pr` COPR with the patched kmodtool
pre-installed in the build chroot.

Two-line diff: swap the COPR that `build-kmod-facetimehd.sh` enables
from `mulderje/facetimehd-kmod` → `mulderje/facetimehd-kmod-pr`.
Everything else from #24 (same-transaction `akmods` + `akmod-*`
install, `getent || useradd` fallback, explicit `akmods --force
--kmod facetimehd`, `modinfo` verify) rides along unchanged.

## What I expect to see in CI

- `dnf5 install -y akmods akmod-facetimehd-*` — succeeds (new `%post`
  is non-fatal on root-guard trip).
- `getent passwd akmods` — succeeds.
- `akmods --force --kernels "${KERNEL}" --kmod facetimehd` — builds
  the module via the akmods → runuser → akmodsbuild chain.
- `modinfo …/facetimehd.ko.xz` — succeeds.
- Full image build completes.

If CI goes green on this branch, that's the clean proof of concept
for the upstream kmodtool patch.

## Revert plan

Once the upstream kmodtool fix ships in stable Fedora and
`mulderje/facetimehd-kmod` (the main COPR) rebuilds against it:

1. Close this PR without merging.
2. Delete branch `claude/scratch-test-kmodtool-1.2-4`.
3. Re-run CI on #24 (unchanged) — it should go green with the stock
   COPR.

## Test plan

- [ ] Confirm `mulderje/facetimehd-kmod-rpm#5`'s Packit build landed
      an `akmod-facetimehd-*` RPM in the `mulderje/facetimehd-kmod-pr`
      COPR (user reports: builds are good)
- [ ] CI run on this branch installs `akmod-facetimehd-*` from
      `mulderje/facetimehd-kmod-pr` without the
      `Transaction failed: Rpm transaction failed.` error
- [ ] `modinfo` succeeds for `facetimehd.ko.xz`
- [ ] Image build finishes end-to-end

https://claude.ai/code/session_01CHV44VRxtpv51BJxxyFehB